### PR TITLE
fix: support unknown whatsapp number

### DIFF
--- a/android/src/main/java/cl/json/social/WhatsAppBusinessShare.java
+++ b/android/src/main/java/cl/json/social/WhatsAppBusinessShare.java
@@ -13,6 +13,11 @@ public class WhatsAppBusinessShare extends SingleShareIntent {
 
     private static final String PACKAGE = "com.whatsapp.w4b";
     private static final String PLAY_STORE_LINK = "market://details?id=com.whatsapp.w4b";
+    
+    private static final String START_CONVERSATION_CLASS = "com.whatsapp.Conversation";
+    private static final String SHARE_TO_CONVERSATION_CLASS = "com.whatsapp.ContactPicker";
+    
+    private static final int START_ACTIVITY_TIME_GAP_MS = 300;
 
     public WhatsAppBusinessShare(ReactApplicationContext reactContext) {
         super(reactContext);
@@ -23,19 +28,19 @@ public class WhatsAppBusinessShare extends SingleShareIntent {
         
         if (options.hasKey("whatsAppNumber")) {
             // create an empty conversation in case it's not on contacts
-            this.getIntent().setComponent(new ComponentName(PACKAGE, "com.whatsapp.Conversation")); 
+            this.getIntent().setComponent(new ComponentName(PACKAGE, START_CONVERSATION_CLASS)); 
             this.openIntentChooser();
 
 
             // leave room for the conversation to be created
             try {
-                Thread.sleep(300);   
+                Thread.sleep(START_ACTIVITY_TIME_GAP_MS);   
             } catch (InterruptedException ex) {
                 ex.printStackTrace();
             }
 
             // share to conversation
-            this.getIntent().setComponent(new ComponentName(PACKAGE, "com.whatsapp.ContactPicker")); 
+            this.getIntent().setComponent(new ComponentName(PACKAGE, SHARE_TO_CONVERSATION_CLASS)); 
         }
 
         //  extra params here

--- a/android/src/main/java/cl/json/social/WhatsAppBusinessShare.java
+++ b/android/src/main/java/cl/json/social/WhatsAppBusinessShare.java
@@ -1,6 +1,7 @@
 package cl.json.social;
 
 import android.content.ActivityNotFoundException;
+import android.content.ComponentName;
 
 import com.facebook.react.bridge.ReactApplicationContext;
 import com.facebook.react.bridge.ReadableMap;
@@ -19,6 +20,24 @@ public class WhatsAppBusinessShare extends SingleShareIntent {
     @Override
     public void open(ReadableMap options) throws ActivityNotFoundException {
         super.open(options);
+        
+        if (options.hasKey("whatsAppNumber")) {
+            // create an empty conversation in case it's not on contacts
+            this.getIntent().setComponent(new ComponentName(PACKAGE, "com.whatsapp.Conversation")); 
+            this.openIntentChooser();
+
+
+            // leave room for the conversation to be created
+            try {
+                Thread.sleep(300);   
+            } catch (InterruptedException ex) {
+                ex.printStackTrace();
+            }
+
+            // share to conversation
+            this.getIntent().setComponent(new ComponentName(PACKAGE, "com.whatsapp.ContactPicker")); 
+        }
+
         //  extra params here
         this.openIntentChooser();
     }

--- a/android/src/main/java/cl/json/social/WhatsAppShare.java
+++ b/android/src/main/java/cl/json/social/WhatsAppShare.java
@@ -13,6 +13,11 @@ public class WhatsAppShare extends SingleShareIntent {
 
     private static final String PACKAGE = "com.whatsapp";
     private static final String PLAY_STORE_LINK = "market://details?id=com.whatsapp";
+        
+    private static final String START_CONVERSATION_CLASS = "com.whatsapp.Conversation";
+    private static final String SHARE_TO_CONVERSATION_CLASS = "com.whatsapp.ContactPicker";
+    
+    private static final int START_ACTIVITY_TIME_GAP_MS = 300;
 
     public WhatsAppShare(ReactApplicationContext reactContext) {
         super(reactContext);
@@ -23,19 +28,19 @@ public class WhatsAppShare extends SingleShareIntent {
         
         if (options.hasKey("whatsAppNumber")) {
             // create an empty conversation in case it's not on contacts
-            this.getIntent().setComponent(new ComponentName(PACKAGE, "com.whatsapp.Conversation")); 
+            this.getIntent().setComponent(new ComponentName(PACKAGE, START_CONVERSATION_CLASS)); 
             this.openIntentChooser();
 
 
             // leave room for the conversation to be created
             try {
-                Thread.sleep(300);   
+                Thread.sleep(START_ACTIVITY_TIME_GAP_MS);   
             } catch (InterruptedException ex) {
                 ex.printStackTrace();
             }
 
             // share to conversation
-            this.getIntent().setComponent(new ComponentName(PACKAGE, "com.whatsapp.ContactPicker")); 
+            this.getIntent().setComponent(new ComponentName(PACKAGE, SHARE_TO_CONVERSATION_CLASS)); 
         }
 
         //  extra params here

--- a/android/src/main/java/cl/json/social/WhatsAppShare.java
+++ b/android/src/main/java/cl/json/social/WhatsAppShare.java
@@ -1,6 +1,7 @@
 package cl.json.social;
 
 import android.content.ActivityNotFoundException;
+import android.content.ComponentName;
 
 import com.facebook.react.bridge.ReactApplicationContext;
 import com.facebook.react.bridge.ReadableMap;
@@ -19,6 +20,24 @@ public class WhatsAppShare extends SingleShareIntent {
     @Override
     public void open(ReadableMap options) throws ActivityNotFoundException {
         super.open(options);
+        
+        if (options.hasKey("whatsAppNumber")) {
+            // create an empty conversation in case it's not on contacts
+            this.getIntent().setComponent(new ComponentName(PACKAGE, "com.whatsapp.Conversation")); 
+            this.openIntentChooser();
+
+
+            // leave room for the conversation to be created
+            try {
+                Thread.sleep(300);   
+            } catch (InterruptedException ex) {
+                ex.printStackTrace();
+            }
+
+            // share to conversation
+            this.getIntent().setComponent(new ComponentName(PACKAGE, "com.whatsapp.ContactPicker")); 
+        }
+
         //  extra params here
         this.openIntentChooser();
     }


### PR DESCRIPTION
# Overview
Workaround for the issue https://github.com/react-native-share/react-native-share/issues/952 . Images were not being shared to a specific number if the conversation was never opened before. The workaround found is to open a blank conversation first, then trying to share it again.

# Test Plan
On the App.js from example app, change the `shareSingleImage` function to the following:

```javascript
  /**
   * This functions share a image passed using the
   * url param
   */
  const shareSingleImage = async () => {
    const shareOptions = {
      title: 'Share file',
      url: images.image1,
      failOnCancel: false,
      social: 'whatsapp',
      whatsAppNumber:
        'Insert a number never contacted before here. Must include the country code, and not include symbols.',
    };

    try {
      const ShareResponse = await Share.shareSingle(shareOptions); // change it to shareSingle();
      setResult(JSON.stringify(ShareResponse, null, 2));
    } catch (error) {
      console.log('Error =>', error);
      setResult('error: '.concat(getErrorString(error)));
    }
  };
```
